### PR TITLE
Refine Controller tests and ApplicationService tests. 

### DIFF
--- a/src/SampleFramework.Services.Tests/Abstractions/BaseServiceTests.cs
+++ b/src/SampleFramework.Services.Tests/Abstractions/BaseServiceTests.cs
@@ -14,39 +14,37 @@ namespace SampleFramework.Services.Tests.Abstractions
             UmbracoContext = GetRoutingContext("/test").UmbracoContext;
             UmbracoHelper = new UmbracoHelper(UmbracoContext);
 
-            MockUmbracoContextFactory = new Mock<IUmbracoContextFactory>();
-            MockUmbracoContextFactory.Setup(x => x.GetUmbracoContext()).Returns(UmbracoContext);
+            UmbracoContextFactoryMock = new Mock<IUmbracoContextFactory>();
+            UmbracoContextFactoryMock.Setup(x => x.GetUmbracoContext()).Returns(UmbracoContext);
 
 
-            MockUmbracoHelperFactory = new Mock<IUmbracoHelperFactory>();
-            MockUmbracoHelperFactory.Setup(x => x.GetUmbracoHelper(UmbracoContext))
+            UmbracoHelperFactoryMock = new Mock<IUmbracoHelperFactory>();
+            UmbracoHelperFactoryMock.Setup(x => x.GetUmbracoHelper(UmbracoContext))
                 .Returns(UmbracoHelper);
 
-            MockQueryFactory = new Mock<IQueryFactory>();
+            QueryFactoryMock = new Mock<IQueryFactory>();
 
-            MockPublishedContentExtensionsWrapper = new Mock<IPublishedContentExtensionsWrapper>();
+            PublishedContentExtensionsWrapperMock = new Mock<IPublishedContentExtensionsWrapper>();
 
-            MockPublishedContentExtensionsWrapperFactory = new Mock<IPublishedContentExtensionsWrapperFactory>();
-            MockPublishedContentExtensionsWrapperFactory.Setup(
+            PublishedContentExtensionsWrapperFactoryMock = new Mock<IPublishedContentExtensionsWrapperFactory>();
+            PublishedContentExtensionsWrapperFactoryMock.Setup(
                 x =>
-                    x.GetPublishedContentExtensionsWrapper(MockUmbracoContextFactory.Object,
-                        MockUmbracoHelperFactory.Object)).Returns(MockPublishedContentExtensionsWrapper.Object);
+                    x.GetPublishedContentExtensionsWrapper(UmbracoContextFactoryMock.Object,
+                        UmbracoHelperFactoryMock.Object)).Returns(PublishedContentExtensionsWrapperMock.Object);
         }
 
         protected UmbracoContext UmbracoContext { get; set; }
 
         protected UmbracoHelper UmbracoHelper { get; set; }
+        
+        protected Mock<IUmbracoHelperFactory> UmbracoHelperFactoryMock { get; set; }
 
+        protected Mock<IUmbracoContextFactory> UmbracoContextFactoryMock { get; set; }
 
+        protected Mock<IQueryFactory> QueryFactoryMock { get; set; }
 
-        protected Mock<IUmbracoHelperFactory> MockUmbracoHelperFactory { get; set; }
+        protected Mock<IPublishedContentExtensionsWrapperFactory> PublishedContentExtensionsWrapperFactoryMock { get; set; }
 
-        protected Mock<IUmbracoContextFactory> MockUmbracoContextFactory { get; set; }
-
-        protected Mock<IQueryFactory> MockQueryFactory { get; set; }
-
-        protected Mock<IPublishedContentExtensionsWrapperFactory> MockPublishedContentExtensionsWrapperFactory { get; set; }
-
-        protected Mock<IPublishedContentExtensionsWrapper> MockPublishedContentExtensionsWrapper { get; set; }
+        protected Mock<IPublishedContentExtensionsWrapper> PublishedContentExtensionsWrapperMock { get; set; }
     }
 }

--- a/src/SampleFramework.Services.Tests/ApplicationServiceTests.cs
+++ b/src/SampleFramework.Services.Tests/ApplicationServiceTests.cs
@@ -1,4 +1,5 @@
-﻿using Moq;
+﻿using System;
+using Moq;
 using NUnit.Framework;
 using SampleFramework.Domain.Models;
 using SampleFramework.Services.Tests.Abstractions;
@@ -10,28 +11,75 @@ namespace SampleFramework.Services.Tests
     public class ApplicationServiceTests : BaseServiceTests
     {
         [Test]
-        public void GetHomePage_ReturnsHomePage()
+        public void GetPageModel_OfStubModelType_PassInDocTypeAliasOfCurrentPage_ReturnStubModelWithInfoOfCurrentPage()
         {
             // Arrange
-            const int MockHomePageId = 1;
+            const string docTypeAlias = "testAlias";
 
-            var applicationService = new ApplicationService(MockQueryFactory.Object, MockUmbracoContextFactory.Object,
-                MockUmbracoHelperFactory.Object,
-                MockPublishedContentExtensionsWrapperFactory.Object);
+            var applicationService = new ApplicationService(QueryFactoryMock.Object, UmbracoContextFactoryMock.Object,
+                UmbracoHelperFactoryMock.Object, PublishedContentExtensionsWrapperFactoryMock.Object);
 
-            var mockHomeNode = new Mock<INode>();
-            mockHomeNode.Setup(x => x.Id).Returns(MockHomePageId);
-            MockQueryFactory.Setup(x => x.GetHomeNode()).Returns(mockHomeNode.Object);
+            var currentNodeMock = new Mock<INode>();
+            currentNodeMock.Setup(x => x.NodeTypeAlias).Returns(docTypeAlias);
+            QueryFactoryMock.Setup(x => x.GetCurrentNode()).Returns(currentNodeMock.Object);
 
-            var homePage = new HomePage { Id = MockHomePageId };
-            MockPublishedContentExtensionsWrapper.Setup(x => x.As<HomePage>(homePage.Id)).Returns(homePage);
+            var stubModel = new StubModel();
+            PublishedContentExtensionsWrapperMock.Setup(x => x.As<StubModel>(currentNodeMock.Object.Id)).Returns(stubModel);
 
             // Act
-            var result = applicationService.GetHomePage();
+            var result = applicationService.GetPageModel<StubModel>(docTypeAlias);
 
             // Assert
             Assert.IsNotNull(result);
-            Assert.AreEqual(homePage, result);
+            Assert.AreEqual(stubModel, result);
         }
+
+        [Test]
+        public void GetPageModel_OfStubModelType_PassInDocTypeAliasNotOfCurrentPage_ShouldGetFirstNodeOfDocTypeAliasAndReturnStubModelWithInfoOfThatNode()
+        {
+            // Arrange
+            const string docTypeAlias = "testAlias";
+            const string currentNodeTypeAlias = "currentNodeAlias";
+
+            var applicationService = new ApplicationService(QueryFactoryMock.Object, UmbracoContextFactoryMock.Object,
+                UmbracoHelperFactoryMock.Object, PublishedContentExtensionsWrapperFactoryMock.Object);
+
+            var currentNodeMock = new Mock<INode>();
+            currentNodeMock.Setup(x => x.NodeTypeAlias).Returns(currentNodeTypeAlias);
+            var nodeMock = new Mock<INode>();
+            nodeMock.Setup(x => x.NodeTypeAlias).Returns(docTypeAlias);
+            QueryFactoryMock.Setup(x => x.GetCurrentNode()).Returns(currentNodeMock.Object);
+            QueryFactoryMock.Setup(x => x.GetFirstNodeOfType(docTypeAlias)).Returns(nodeMock.Object);
+
+            var stubModel = new StubModel();
+            PublishedContentExtensionsWrapperMock.Setup(x => x.As<StubModel>(nodeMock.Object.Id)).Returns(stubModel);
+
+            // Act
+            var result = applicationService.GetPageModel<StubModel>(docTypeAlias);
+
+            // Assert
+            Assert.IsNotNull(result);
+            Assert.AreEqual(stubModel, result);
+        }
+
+        [Test]
+        public void GetPageModel_OfStubModelType_PassInDocumentTypeAlias_PageNodeNotExist_ThrowNullException()
+        {
+            // Arrange
+            const string docTypeAlias = "testAlias";
+
+            var applicationService = new ApplicationService(QueryFactoryMock.Object, UmbracoContextFactoryMock.Object,
+                UmbracoHelperFactoryMock.Object, PublishedContentExtensionsWrapperFactoryMock.Object);
+            
+            QueryFactoryMock.Setup(x => x.GetCurrentNode()).Returns((INode) null);
+            QueryFactoryMock.Setup(x => x.GetFirstNodeOfType(docTypeAlias)).Returns((INode)null);
+
+            // Act & Assert
+            Assert.Throws<NullReferenceException>(() => applicationService.GetPageModel<StubModel>(docTypeAlias));
+        }
+    }
+
+    class StubModel : BasePage
+    {
     }
 }

--- a/src/SampleFramework.Services.Tests/SampleFramework.Services.Tests.csproj
+++ b/src/SampleFramework.Services.Tests/SampleFramework.Services.Tests.csproj
@@ -318,6 +318,10 @@
       <Project>{d3eea823-3c1f-4deb-bde9-9900d9359be4}</Project>
       <Name>SampleFramework.Services</Name>
     </ProjectReference>
+    <ProjectReference Include="..\SampleFramework.Shared\SampleFramework.Shared.csproj">
+      <Project>{132E8898-8CA8-4573-809E-D6889086C0FA}</Project>
+      <Name>SampleFramework.Shared</Name>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/src/SampleFramework.Services/ApplicationService.cs
+++ b/src/SampleFramework.Services/ApplicationService.cs
@@ -16,23 +16,16 @@ namespace SampleFramework.Services
         
         public T GetPageModel<T>(string docTypeAlias) where T : BasePage
         {
-            var pageNode = QueryFactory.GetNodeByType(docTypeAlias);
+            var pageNode = QueryFactory.GetCurrentNode();
+
+            if (pageNode.NodeTypeAlias != docTypeAlias)
+            {
+                pageNode = QueryFactory.GetFirstNodeOfType(docTypeAlias);
+            }
 
             if (pageNode == null)
             {
                 throw new NullReferenceException($"Page with {docTypeAlias} document type is NOT available.");
-            }
-
-            return PublishedContentExtensionsWrapper.As<T>(pageNode.Id);
-        }
-
-        public T GetModelOfCurrentPage<T>(string docTypeAlias) where T : BasePage
-        {
-            var pageNode = QueryFactory.GetCurrentNodeWithType(docTypeAlias);
-
-            if (pageNode == null)
-            {
-                throw new NullReferenceException($"Document type of the current page is different from {docTypeAlias}.");
             }
 
             return PublishedContentExtensionsWrapper.As<T>(pageNode.Id);

--- a/src/SampleFramework.Services/Factories/QueryFactory.cs
+++ b/src/SampleFramework.Services/Factories/QueryFactory.cs
@@ -1,6 +1,5 @@
 ﻿using System.Linq;
 using SampleFramework.Services.Interfaces;
-using SampleFramework.Shared.Constants;
 using umbraco;
 using umbraco.interfaces;
 
@@ -8,15 +7,14 @@ namespace SampleFramework.Services.Factories
 {
     public class QueryFactory : IQueryFactory
     {
-        public INode GetNodeByType(string docTypeAlias)
+        public INode GetFirstNodeOfType(string docTypeAlias)
         {
             return uQuery.GetNodesByType(docTypeAlias).FirstOrDefault();
         }
 
-        public INode GetCurrentNodeWithType(string docTypeAlias)
+        public INode GetCurrentNode()
         {
-            var currentNode = uQuery.GetCurrentNode();
-            return currentNode.NodeTypeAlias == docTypeAlias ? currentNode : null;
+            return uQuery.GetCurrentNode();
         }
     }
 }

--- a/src/SampleFramework.Services/Interfaces/IApplicationService.cs
+++ b/src/SampleFramework.Services/Interfaces/IApplicationService.cs
@@ -5,7 +5,5 @@ namespace SampleFramework.Services.Interfaces
     public interface IApplicationService
     {
         T GetPageModel<T>(string docTypeAlias) where T : BasePage;
-
-        T GetModelOfCurrentPage<T>(string docTypeAlias) where T : BasePage;
     }
 }

--- a/src/SampleFramework.Services/Interfaces/IQueryFactory.cs
+++ b/src/SampleFramework.Services/Interfaces/IQueryFactory.cs
@@ -4,8 +4,8 @@ namespace SampleFramework.Services.Interfaces
 {
     public interface IQueryFactory
     {
-        INode GetNodeByType(string docTypeAlias);
+        INode GetFirstNodeOfType(string docTypeAlias);
 
-        INode GetCurrentNodeWithType(string docTypeAlias);
+        INode GetCurrentNode();
     }
 }

--- a/src/SampleFramework.Web.Tests/Abstractions/BaseControllerTests.cs
+++ b/src/SampleFramework.Web.Tests/Abstractions/BaseControllerTests.cs
@@ -1,5 +1,6 @@
 ﻿using Moq;
 using NUnit.Framework;
+using SampleFramework.Services.Interfaces;
 using SampleFramework.Web.App_Start;
 using Umbraco.Core.Models;
 using Umbraco.Tests.TestHelpers;
@@ -8,12 +9,18 @@ namespace SampleFramework.Web.Tests.Abstractions
 {
     public abstract class BaseControllerTests : BaseRoutingTest
     {
+        protected static int CurrentPageId => 1000;
+
+        protected Mock<IApplicationService> ApplicationServiceMock { get; set; }
+
         [SetUp]
         public void SetUp()
         {
             AutoMapperConfig.RegisterAutoMapper();
 
             GetRoutingContext("/test", 1234, setUmbracoContextCurrent: true);
+
+            ApplicationServiceMock = new Mock<IApplicationService>();
         }
 
         protected static IPublishedContent MockIPublishedContent()
@@ -22,7 +29,5 @@ namespace SampleFramework.Web.Tests.Abstractions
             mock.Setup(x => x.Id).Returns(CurrentPageId);
             return mock.Object;
         }
-
-        protected static int CurrentPageId => 1000;
     }
 }

--- a/src/SampleFramework.Web.Tests/HomePageControllerTests.cs
+++ b/src/SampleFramework.Web.Tests/HomePageControllerTests.cs
@@ -1,10 +1,11 @@
 ﻿using System.Web.Mvc;
 using NUnit.Framework;
+using SampleFramework.Domain.Models;
 using SampleFramework.Services;
+using SampleFramework.Shared.Constants;
 using SampleFramework.Web.Controllers;
 using SampleFramework.Web.Models;
 using SampleFramework.Web.Tests.Abstractions;
-using SampleFramework.Web.Tests.Stubs;
 
 namespace SampleFramework.Web.Tests
 {
@@ -21,12 +22,16 @@ namespace SampleFramework.Web.Tests
         public void Index_Get_ReturnsHomePageViewModel()
         {
             // Arrange
+            const int homePageId = 1;
 
-            var applicationService = new StubApplicationService();
-            var controller = new HomePageController(applicationService);
-            controller.MapModelService = new MapModelService();
+            var controller = new HomePageController
+            {
+                ApplicationService = ApplicationServiceMock.Object,
+                MapModelService = new MapModelService()
+            };
 
-            var homePage = applicationService.GetHomePage();
+            var homePage = new HomePage { Id = homePageId };
+            ApplicationServiceMock.Setup(x => x.GetPageModel<HomePage>(DocTypeAliases.HomePage.Alias)).Returns(homePage);
 
             var homePageViewModel = controller.MapModelService.Map<HomePageViewModel>(homePage);
 

--- a/src/SampleFramework.Web.Tests/SampleFramework.Web.Tests.csproj
+++ b/src/SampleFramework.Web.Tests/SampleFramework.Web.Tests.csproj
@@ -292,7 +292,6 @@
     <Compile Include="Abstractions\BaseControllerTests.cs" />
     <Compile Include="HomePageControllerTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Stubs\StubApplicationService.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />
@@ -321,6 +320,10 @@
     <ProjectReference Include="..\SampleFramework.Services\SampleFramework.Services.csproj">
       <Project>{d3eea823-3c1f-4deb-bde9-9900d9359be4}</Project>
       <Name>SampleFramework.Services</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\SampleFramework.Shared\SampleFramework.Shared.csproj">
+      <Project>{132E8898-8CA8-4573-809E-D6889086C0FA}</Project>
+      <Name>SampleFramework.Shared</Name>
     </ProjectReference>
     <ProjectReference Include="..\SampleFramework.Web\SampleFramework.Web.csproj">
       <Project>{800e53f9-fe66-40a6-96ea-341a0befdaad}</Project>

--- a/src/SampleFramework.Web.Tests/Stubs/StubApplicationService.cs
+++ b/src/SampleFramework.Web.Tests/Stubs/StubApplicationService.cs
@@ -5,10 +5,14 @@ namespace SampleFramework.Web.Tests.Stubs
 {
     public class StubApplicationService : IApplicationService
     {
-        public HomePage GetHomePage()
+        public T GetPageModel<T>(string docTypeAlias) where T : BasePage
         {
-            var homePage = new HomePage { Id = 1 };
-            return homePage;
+            throw new System.NotImplementedException();
+        }
+
+        public T GetModelOfCurrentPage<T>(string docTypeAlias) where T : BasePage
+        {
+            throw new System.NotImplementedException();
         }
     }
 }


### PR DESCRIPTION
Refine GetPageModel method of ApplicationService to check current page before searching for fist node of the alias type